### PR TITLE
성능 최적화를 위한 코드 개선

### DIFF
--- a/src/components/ProductList.tsx
+++ b/src/components/ProductList.tsx
@@ -191,6 +191,8 @@ export const ProductList = () => {
 						src={item.product.imageUrl}
 						alt={item.product.name}
 						loading={idx < initialSize ? 'eager' : 'lazy'}
+						fetchPriority={idx < initialSize ? 'high' : 'auto'}
+						decoding={idx >= initialSize ? 'async' : 'auto'}
 					/>
 					<ProductTitle>{item.product.name}</ProductTitle>
 

--- a/src/components/ProductList.tsx
+++ b/src/components/ProductList.tsx
@@ -118,6 +118,7 @@ export const ProductList = () => {
 		setPage,
 		loadProducts,
 		reset,
+		initialSize,
 	} = useProductsInfinite();
 	const observerRef = useRef<HTMLDivElement>(null);
 	const { goToCategory, goToProductDetail } = useNavigation();
@@ -182,14 +183,14 @@ export const ProductList = () => {
 
 	return (
 		<ProductListContainer>
-			{products.map((item) => (
+			{products.map((item, idx) => (
 				<ProductCard
 					key={`${item.product.id}-${item.stock.id}`}
 					onClick={() => goToProductDetail(item.stock.id)}>
 					<ProductImage
 						src={item.product.imageUrl}
 						alt={item.product.name}
-						loading='lazy'
+						loading={idx < initialSize ? 'eager' : 'lazy'}
 					/>
 					<ProductTitle>{item.product.name}</ProductTitle>
 

--- a/src/hooks/products/useProductsInfinite.ts
+++ b/src/hooks/products/useProductsInfinite.ts
@@ -18,6 +18,7 @@ export const useProductsInfinite = () => {
 	const [hasNextPage, setHasNextPage] = useState(true);
 	const [isLoading, setIsLoading] = useState(false);
 	const [query, setQuery] = useState<ProductQueryParams>({});
+	const initialSize = estimateInitialSize();
 
 	const loadProducts = useCallback(
 		async (pageNum: number, newQuery?: ProductQueryParams) => {
@@ -29,7 +30,7 @@ export const useProductsInfinite = () => {
 
 				const res = await getProducts({
 					page: pageNum,
-					size: pageNum === 0 ? estimateInitialSize() : 10,
+					size: pageNum === 0 ? initialSize : 10,
 					search: mergedQuery.search ?? ' ',
 					category: mergedQuery.category ?? undefined,
 					minPrice: mergedQuery.minPrice,
@@ -65,5 +66,6 @@ export const useProductsInfinite = () => {
 		setPage,
 		loadProducts,
 		reset,
+		initialSize,
 	};
 };

--- a/src/utils/__tests__/estimateInitialSize.test.ts
+++ b/src/utils/__tests__/estimateInitialSize.test.ts
@@ -42,11 +42,11 @@ describe('estimateInitialSize', () => {
 		expect(estimateInitialSize()).toBe(20);
 	});
 
-	it('작은 화면에 맞게 계산된다', () => {
+	it('최소 렌더링 아이템 개수는 6개이다', () => {
 		window.innerHeight = 600;
 		window.innerWidth = 375;
 		// rows = ceil(600 / 316) = 2
 		// columns = floor(375 / 220) = 1
-		expect(estimateInitialSize()).toBe(2);
+		expect(estimateInitialSize()).toBe(6);
 	});
 });

--- a/src/utils/estimateInitialSize.ts
+++ b/src/utils/estimateInitialSize.ts
@@ -3,7 +3,7 @@ const estimateInitialSize = () => {
 	const gap = 16;
 	const rows = Math.ceil(window.innerHeight / (itemHeight + gap));
 	const columns = Math.floor(window.innerWidth / 220);
-	return rows * columns;
+	return Math.max(rows * columns, 6);
 };
 
 export default estimateInitialSize;


### PR DESCRIPTION
- estimateInitialSize 함수에서 화면이 많이 작더라도 최소 렌더링 아이템 개수가 6개는 되도록 수정
- 이 함수에서 반환하는 값을 initialSize로 받음
- 이 수치를 이용하여 이미지 렌더링 옵션을 idx<initialSize 일때 eager로 처리하도록 하여 LCP 개선 기대
